### PR TITLE
Fix uv install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ Or, to install and develop locally using `uv`:
 3. **Install with uv**
 
    ```bash
-   uv install       # Installs dependencies from pyproject.toml
-   uv develop       # Editable install for live coding
+   uv pip install .            # Installs dependencies from pyproject.toml
+   uv pip install --editable . # Editable install for live coding
    ```
 
 4. **Run locally**

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -5,7 +5,7 @@ virtual environment and install dependencies before packaging for PyPI:
 
 ```bash
 uv venv .venv
-uv install
+uv pip install .
 ```
 
 `uv` automatically detects the `.venv` directory, so activation isn't

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -6,7 +6,7 @@
 
   ```bash
   uv venv .venv
-  uv install
+  uv pip install .
   ```
 
   You don't need to activate the environment when running `uv` commands.


### PR DESCRIPTION
## Summary
- update README and docs to use `uv pip install`

## Testing
- `uv venv .venv`
- `uv pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857c4bf2e90832b8793b5add995a08a