### PR TITLE
Add CLI entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ This repository provides a reference implementation of **OpenAPI Tool Servers**â
 - **Interactive Docs**: Swagger UI at `/doc`
 - **Stubbed Endpoints**: Prebuilt routers (`/time`, `/echo`, `/math`) returning canned data
 - **Packaging**: Managed via `uv` with `pyproject.toml` ready for PyPI
+- **CLI**: Start the server with the `example-openapi-tools-server` command
 - **Dockerized**: Official `Dockerfile` for quick container builds with examples how you can get your server running with minimal effort
 - **Examples**: Integration snippets for Open WebUI, MCPO, LangChain, Langflow and others
 
@@ -74,7 +75,7 @@ Or, to install and develop locally using `uv`:
 4. **Run locally**
 
    ```bash
-   uv run --host 0.0.0.0 --port 8123
+   example-openapi-tools-server --host 0.0.0.0 --port 8123
    ```
 
 Visit [http://localhost:8123/docs](http://localhost:8123/docs) to explore.

--- a/app/__main__.py
+++ b/app/__main__.py
@@ -1,0 +1,4 @@
+from .cli import entrypoint
+
+if __name__ == "__main__":
+    entrypoint()

--- a/app/cli.py
+++ b/app/cli.py
@@ -1,0 +1,15 @@
+import uvicorn
+import typer
+
+
+def main(host: str = "127.0.0.1", port: int = 8123) -> None:
+    """Start Example OpenAPI Tools Server."""
+    uvicorn.run("app.main:app", host=host, port=port)
+
+
+def entrypoint() -> None:
+    typer.run(main)
+
+
+if __name__ == "__main__":
+    entrypoint()

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -25,3 +25,7 @@
   tracked and verified. Use the prefix `REQ-` followed by a sequence number
   (for example `REQ-001`, `REQ-002`, and so on).
 
+* **REQ-005**: Tool servers MUST provide a command-line interface to start the
+  service. The CLI SHOULD expose `--host` and `--port` options so users can run
+  the server after installing it from PyPI or GitHub.
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,11 @@ dependencies = [
     "fastapi>=0.110",
     "uvicorn[standard]>=0.23",
     "pyyaml>=6",
+    "typer",
 ]
 
-[tool.setuptools.packages.find]
-where = ["app"]
+[tool.setuptools]
+packages = ["app", "app.routers"]
+
+[project.scripts]
+example-openapi-tools-server = "app.cli:entrypoint"


### PR DESCRIPTION
## Summary
- provide a Typer-based CLI for starting the server
- expose CLI via `example-openapi-tools-server` console script
- document command line usage and add requirement REQ-005

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6857c5fc9128832b8165914e9ab054df