### PR TITLE
Show docs URL on server startup

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -1,9 +1,12 @@
+import os
 import uvicorn
 import typer
 
 
 def main(host: str = "127.0.0.1", port: int = 8123) -> None:
     """Start Example OpenAPI Tools Server."""
+    os.environ["SERVER_HOST"] = host
+    os.environ["SERVER_PORT"] = str(port)
     uvicorn.run("app.main:app", host=host, port=port)
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -2,6 +2,7 @@ from fastapi import FastAPI
 from .routers import time, echo, math
 import yaml
 import os
+import logging
 
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 SPEC_PATH = os.path.join(BASE_DIR, "openapi.yaml")
@@ -11,6 +12,15 @@ app = FastAPI(openapi_url="/openapi.json", docs_url="/docs", redoc_url="/redoc")
 # Load OpenAPI spec from YAML file and use it for the /openapi.json route
 with open(SPEC_PATH, "r") as f:
     openapi_schema = yaml.safe_load(f)
+
+
+@app.on_event("startup")
+async def log_docs_url() -> None:
+    """Log the documentation URL when the app starts."""
+    host = os.getenv("SERVER_HOST", "127.0.0.1")
+    port = os.getenv("SERVER_PORT", "8123")
+    logger = logging.getLogger("uvicorn")
+    logger.info("Docs available at http://%s:%s%s", host, port, app.docs_url)
 
 @app.get("/openapi.json", include_in_schema=False)
 async def get_openapi_spec():


### PR DESCRIPTION
## Summary
- set host/port env vars in CLI for later use
- log documentation URL on startup

## Testing
- `python -m app.main`

------
https://chatgpt.com/codex/tasks/task_e_6857c8ba13a0832bbfde27500c72d851